### PR TITLE
Add ./templates to package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "bantam",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Scalable, performant, responsive, CSS framework with zero styles.",
   "author": "Colm Tuite <colmtuite@gmail.com> (http://www.colmtuite.com)",
   "style": "css/bantam.css",
   "main": "css/bantam.css",
   "files": [
     "css",
-    "src"
+    "src",
+    "templates"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Without this, the package hosted on npm doesn't include the
`./templates` directory. This is a problem because no templates
directory will exist when I run `npm install` inside `bantam-docs` to
install the dependencies. This means I can't reach into the
`node_modules/bantam/templates` directory to discover the templates.

Note: You'll have to publish again before I can continue.